### PR TITLE
add npmignore to keep final npm package clean

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,5 @@
+**/__mocks__/**
+**/__tests__/**
+.npmignore
+cloudbuild.yaml
+coverage


### PR DESCRIPTION
small improvement to keep final npm package clean since no test / mock or build information is needed in final package